### PR TITLE
add error check to logs client

### DIFF
--- a/piku_dashboard/piku_client.py
+++ b/piku_dashboard/piku_client.py
@@ -51,6 +51,9 @@ def all_apps():
 def logs(appid):
     logfiles = glob.glob(os.path.join(LOG_ROOT, appid, "*" + ".*.log"))
 
+    if len(logfiles) < 1:
+        raise ValueError("No log files found, likely bad appid")
+
     logger.debug("found logfiles for %s: %s", appid, logfiles)
 
     logcontent = {}


### PR DESCRIPTION
All workers have logs, so zero logfiles indicates an error.

Fixes #12 