### PR TITLE
change new version SHA match to startswith

### DIFF
--- a/piku_dashboard/main.py
+++ b/piku_dashboard/main.py
@@ -47,8 +47,7 @@ def get_github_sha():
         response = requests.get("https://api.github.com/repos/rwnx/piku-dashboard/commits")
         history = response.json()
 
-        sha = history[0]['sha'][:6]
-        return sha
+        return history[0]['sha']
     except:
         return "invalid_sha"
 

--- a/piku_dashboard/templates/home.html
+++ b/piku_dashboard/templates/home.html
@@ -18,7 +18,7 @@
   <aside>
     <h2>{{app.id}} <sup class="applabel-{{ "active" if app.active else "inactive" }}">{{ 'Active' if app.active else 'Inactive' }}</sup></h2>
       <ul class="app-meta">
-          <li>{{app.ref}}{% if github_sha != app.ref and app.id == self_app %}<a href="https://github.com/rwnx/piku-dashboard" target="_blank">New Version</a>{% endif %}</li>
+          <li>{{app.ref}} {% if github_sha.startswith(app.ref) and app.id == self_app %}<a href="https://github.com/rwnx/piku-dashboard" target="_blank">New Version</a>{% endif %}</li>
       </ul>
     <ul>
       <li><a href="{{url_for('app_logs', appid=app.id)}}">📖 View Logs</a></li>


### PR DESCRIPTION
* the github SHA will be the full SHA, so we assume app.ref is the smaller component.
* I've changed the get_github_sha method to return the full SHA, for utility purposes. other consumers can always truncate later
* I also corrected a spacing issue between the new version text and the app.ref


NB: I'm doing this blind because i'm unable to test from here. this SO post seems to indicate that startswith is possible: 
https://stackoverflow.com/questions/28346000/method-similar-to-startswith-in-jinja2-flask

Closes #36 